### PR TITLE
show device ble address

### DIFF
--- a/fido2ble_to_uhid/CTAPHIDDevice.py
+++ b/fido2ble_to_uhid/CTAPHIDDevice.py
@@ -40,11 +40,15 @@ class CTAPHIDDevice:
     def __init__(self, ble_device):
         # This could then also include the proper name, VID, PID and so on
         self.ble_device = ble_device
+        addr = ble_device.device_id.split("_")[1:]
+        vid = int("".join(addr[0:2]), 16)
+        pid = int("".join(addr[2:4]), 16)
+        name = "PONE Fido2BLE Proxy %s" % (":".join(addr))
         try:
             self.device = uhid.UHIDDevice(
-                vid=0xAAAA,
-                pid=0xAAAA,  # these are the yubikey VID and PID. These need to change for prod.
-                name="PONE Fido2BLE Proxy",
+                vid,
+                pid,
+                name,
                 report_descriptor=[
                     0x06,
                     0xD0,

--- a/fido2ble_to_uhid/fido2ble_to_uhid.py
+++ b/fido2ble_to_uhid/fido2ble_to_uhid.py
@@ -75,15 +75,10 @@ async def start_system():
         # noinspection PyAsyncCall
         asyncio.create_task(hid.start())
         hid_devices.append(hid)
+    await asyncio.Event().wait()
 
 def main():
-    loop = asyncio.get_event_loop()
-    try:
-        loop.run_until_complete(start_system())
-        loop.run_forever()  # run queued dispatch tasks
-        loop.close()
-    except KeyboardInterrupt:
-        loop.close()
+    asyncio.run(start_system())
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Uses the BLE address in the vid/pid and name of the device so it is easy to tell different FIDO2 devices apart.

```
$ fido2-token -L
/dev/hidraw6: vendor=0x37ce, product=0x0202 (PONE Biometrics OFFPAD+)
/dev/hidraw7: vendor=0xcacb, product=0xc3fd ( PONE Fido2BLE Proxy CA:CB:C3:FD:AB:ED)
```

- **CTAPHIDDevice: show ble address of hiddevice**
- **fido2ble_to_uhid: use newer event loop**
