### PR TITLE
Dont create multiple timeouts. Fixes #20

### DIFF
--- a/fido2ble_to_uhid/CTAPBLEDevice.py
+++ b/fido2ble_to_uhid/CTAPBLEDevice.py
@@ -119,7 +119,7 @@ class CTAPBLEDevice:
             await self.reconnect()
 
         self.has_connected = True
-        self.timeout = 5000  # Way higher than should be until we fix keep alive interval on card
+        self.timeout = 3000
         logging.debug(f"Connection complete: {self.device_id}")
         return self
 
@@ -159,6 +159,7 @@ class CTAPBLEDevice:
         logging.debug(f"ble tx: command={command.name} device={self.device_id} payload={payload.hex()}")
         offset_start = 0
         seq = 0
+        self.keep_alive()
         while offset_start < len(payload) or offset_start == 0:
             if seq == 0:
                 capacity = self.max_msg_size - 3
@@ -180,4 +181,4 @@ class CTAPBLEDevice:
         return None
 
     def keep_alive(self):
-        self.timeout = 5000
+        self.timeout = 3000


### PR DESCRIPTION
The old code would create multiple check timeout tasks, which would all run in parallell and subtract from the same timeout value, leading to this value reaching 0 much quicker than intended.

Change this to only create a new timeout task if none exists, or the previous one has completed.

Shrink the timeout to 3 sec to be more snappy, and add a timeout update to messages sent, not just received