### PR TITLE
Fix reconnect logic, add stability #24

### DIFF
--- a/fido2ble_to_uhid/CTAPBLEDevice.py
+++ b/fido2ble_to_uhid/CTAPBLEDevice.py
@@ -3,6 +3,8 @@ import asyncio
 import logging
 import struct
 from functools import partial
+
+from .vendored.dbus_fast import DBusError
 from .vendored.dbus_fast import BusType
 from .vendored.dbus_fast.aio import ProxyInterface, MessageBus
 
@@ -16,17 +18,20 @@ def notify_message(handler, interface_name, changed_properties, invalidated_prop
     if 'Value' in changed_properties:
         handler(changed_properties['Value'].value)
 
+
 FIDO_CONTROL_POINT_UUID = "f1d0fff1-deaa-ecee-b42f-c9ba7ed623bb"
 FIDO_STATUS_UUID = "f1d0fff2-deaa-ecee-b42f-c9ba7ed623bb"
 FIDO_CONTROL_POINT_LENGTH_UUID = "f1d0fff3-deaa-ecee-b42f-c9ba7ed623bb"
 FIDO_SERVICE_REVISION_BITFIELD_UUID = "f1d0fff4-deaa-ecee-b42f-c9ba7ed623bb"
 
+
 async def find_characteristics(device_path, objects, characteristic_paths):
     # Iterate through objects to find the characteristic with the target UUID
     if objects is None:
         bus: MessageBus = await MessageBus(bus_type=BusType.SYSTEM).connect()
-        bluez_introspect = await bus.introspect("org.bluez",'/')
-        dbus_proxy = bus.get_proxy_object('org.bluez','/', bluez_introspect)
+        bluez_introspect = await bus.introspect("org.bluez", '/')
+        dbus_proxy = bus.get_proxy_object('org.bluez', '/', bluez_introspect)
+        # noinspection PyUnresolvedReferences
         objects = await dbus_proxy.get_interface("org.freedesktop.DBus.ObjectManager").call_get_managed_objects()
 
     for path, interfaces in objects.items():
@@ -37,11 +42,13 @@ async def find_characteristics(device_path, objects, characteristic_paths):
                 if uuid in characteristic_paths:
                     characteristic_paths[uuid] = path
 
+DEFAULT_TIMEOUT = 3000  # milliseconds
+
 class CTAPBLEDevice:
-    device: ProxyInterface  # org.bluez.Device1
+    device1_interface: ProxyInterface  # org.bluez.Device1
     device_id: str
     connected = False
-    timeout = 5000
+    timeout = DEFAULT_TIMEOUT
     cached = False
 
     fido_control_point_path: str
@@ -49,38 +56,46 @@ class CTAPBLEDevice:
     fido_control_point_length_path: str
     fido_status_path: str
     fido_status: ProxyInterface  # org.bluez.GattCharacteristic1
-    fido_status_notify_listen: ProxyInterface  # org.freedesktop.DBus.Properties
+    fido_status_notify_listen: ProxyInterface  # org.freedesktop.DBus.Properties at fido status path
     max_msg_size: int
     handler = None
+    device_properties_interface: ProxyInterface  # org.freedesktop.DBus.Properties at device top level
+    properties_changed_listener_active: bool = False  # Flag to track if listener is active
 
-    def __init__(self, device: ProxyInterface, device_id: str, cached: bool, control_point_path, control_point_length_path, status_path):
-        self.device = device
+    def __init__(self, device_proxy, device1: ProxyInterface, device_id: str, cached: bool, control_point_path, control_point_length_path, status_path):
+        self.device_proxy = device_proxy
+        self.device1_interface = device1
         self.device_id = device_id
         self.max_msg_size = 0
         self.cached = cached
         self.fido_control_point_path = control_point_path
         self.fido_control_point_length_path = control_point_length_path
         self.fido_status_path = status_path
-        self.has_connected = False
+        self.connected = False
+        self.device_properties_interface = self.device_proxy.get_interface('org.freedesktop.DBus.Properties')
 
     async def connect(self, handler):
-        if self.has_connected == True:
+        if self.connected:
             return self
-        if self.max_msg_size == 0: # If we know Max Msg we have done this at least once. Don't want to redo it
+
+        self.setup_signal_handler()
+        if self.max_msg_size == 0:  # If we know Max Msg we have done this at least once. Don't want to redo it
             self.handler = partial(notify_message, handler)
             bus: MessageBus = await MessageBus(bus_type=BusType.SYSTEM).connect()
             logging.debug(f"Attempting to connect to {self.device_id}")
             # noinspection PyUnresolvedReferences
-            await self.device.call_connect()
+            await self.device1_interface.call_connect()
 
             # If the OS lacked data on this before we need to re-fetch data and reconnect but has to be a better way somehow
             if not self.cached:
-                await self.device.call_disconnect()
+                # noinspection PyUnresolvedReferences
+                await self.device1_interface.call_disconnect()
                 device_introspect = await bus.introspect('org.bluez', self.device_id)
-                device_proxy = bus.get_proxy_object('org.bluez', self.device_id, device_introspect)
-                self.device = device_proxy.get_interface('org.bluez.Device1')
+                self.device_proxy = bus.get_proxy_object('org.bluez', self.device_id, device_introspect)
+                self.device1_interface = self.device_proxy.get_interface('org.bluez.Device1')
                 self.cached = True
-                await self.device.call_connect()
+                # noinspection PyUnresolvedReferences
+                await self.device1_interface.call_connect()
 
             if self.fido_control_point_path is None or self.fido_control_point_length_path is None or self.fido_status_path is None:
                 characteristic_paths = {
@@ -90,7 +105,7 @@ class CTAPBLEDevice:
                 }
                 await find_characteristics(self.device_id, None, characteristic_paths)
                 self.fido_control_point_path = characteristic_paths[FIDO_CONTROL_POINT_UUID]
-                self.fido_control_point_length_path=characteristic_paths[FIDO_CONTROL_POINT_LENGTH_UUID]
+                self.fido_control_point_length_path = characteristic_paths[FIDO_CONTROL_POINT_LENGTH_UUID]
                 self.fido_status_path = characteristic_paths[FIDO_STATUS_UUID]
 
             control_point_length_proxy = bus.get_proxy_object('org.bluez', self.fido_control_point_length_path,
@@ -102,8 +117,8 @@ class CTAPBLEDevice:
             status_characteristic = status_proxy.get_interface('org.bluez.GattCharacteristic1')
             notify_properties = status_proxy.get_interface('org.freedesktop.DBus.Properties')
 
-            control_point_proxy = bus.get_proxy_object('org.bluez',  self.fido_control_point_path,
-                                                       await bus.introspect('org.bluez',  self.fido_control_point_path))
+            control_point_proxy = bus.get_proxy_object('org.bluez', self.fido_control_point_path,
+                                                       await bus.introspect('org.bluez', self.fido_control_point_path))
             control_point = control_point_proxy.get_interface('org.bluez.GattCharacteristic1')
             # noinspection PyUnresolvedReferences
             self.max_msg_size = int.from_bytes(bytes(await control_point_length.call_read_value({})), "big")
@@ -112,50 +127,55 @@ class CTAPBLEDevice:
             self.fido_control_point = control_point
             self.fido_status = status_characteristic
             self.fido_status_notify_listen = notify_properties
-            self.connected = True
             await self.listen_to_notify()
         else:
-            logging.debug(f"Device already connected: {self.device_id}")
+            logging.debug(f"Device previously connected: {self.device_id}")
             await self.reconnect()
 
-        self.has_connected = True
-        self.timeout = 3000
+        self.keep_alive()
         logging.debug(f"Connection complete: {self.device_id}")
         return self
 
     async def reconnect(self):
-        # noinspection PyUnresolvedReferences
-        await self.device.call_connect()
-        await self.listen_to_notify()
+        try:
+            # noinspection PyUnresolvedReferences
+            await self.device1_interface.call_connect()
+        except Exception as error:
+            logging.warning(f"Unable to reconnect to {self.device_id}, error: {error}")
+        try:
+            await self.listen_to_notify()
+        except Exception as error:
+            logging.warning(f"Unable to listen to notify when reconnecting to {self.device_id}, error: {error}")
 
     async def disconnect(self):
-        if self.has_connected == False:
-            return
-        self.has_connected = False
+        if self.connected:
+            self.connected = False #Has to be here to avoid sending messages while waiting for disconnect to finish
+            logging.debug(f"Disconnecting: {self.device_id}")
+            # noinspection PyUnresolvedReferences
+            await self.fido_status.call_stop_notify()
+            # noinspection PyUnresolvedReferences
+            await self.device1_interface.call_disconnect()
         # noinspection PyUnresolvedReferences
-        logging.debug(f"Disconnecting: {self.device_id}")
         self.fido_status_notify_listen.off_properties_changed(self.handler)
-        # noinspection PyUnresolvedReferences
-        await self.fido_status.call_stop_notify()
-        # noinspection PyUnresolvedReferences
-        await self.device.call_disconnect()
-        self.connected = False
 
-    async def write_data(self, payload):
-        while not self.has_connected:
-            logging.debug("Waiting to connect")
-            await asyncio.sleep(0.5)
-
-        # noinspection PyUnresolvedReferences
-        await self.fido_control_point.call_write_value(payload, {})
+    async def write_data(self, payload: bytes):
+        try:
+            while not self.connected:
+                logging.debug("Waiting to connect")
+                await self.reconnect()
+            # noinspection PyUnresolvedReferences
+            await self.fido_control_point.call_write_value(payload, {})
+        except DBusError as error:
+            logging.error(f"Unable to write to {self.device_id}, error: {error}")
 
     async def listen_to_notify(self):
-        # noinspection PyUnresolvedReferences
-        self.fido_status_notify_listen.on_properties_changed(self.handler)
-        # noinspection PyUnresolvedReferences
-        await self.fido_status.call_start_notify()
+        if self.connected:
+            # noinspection PyUnresolvedReferences
+            self.fido_status_notify_listen.on_properties_changed(self.handler)
+            # noinspection PyUnresolvedReferences
+            await self.fido_status.call_start_notify()
 
-    async def send_ble_message(self, command: CTAPBLE_CMD, payload:bytes):
+    async def send_ble_message(self, command: CTAPBLE_CMD, payload: bytes):
         logging.debug(f"ble tx: command={command.name} device={self.device_id} payload={payload.hex()}")
         offset_start = 0
         seq = 0
@@ -167,7 +187,7 @@ class CTAPBLEDevice:
             else:
                 capacity = self.max_msg_size - 1
                 response = struct.pack(">B", seq - 1)
-            response += payload[offset_start : (offset_start + capacity)]
+            response += payload[offset_start: (offset_start + capacity)]
 
             await self.write_data(response)
 
@@ -175,10 +195,30 @@ class CTAPBLEDevice:
             seq += 1
 
     def get_connected_ble(self):
-        if self.has_connected:
+        if self.connected:
             return self
 
         return None
 
     def keep_alive(self):
-        self.timeout = 3000
+        self.timeout = DEFAULT_TIMEOUT
+
+    def properties_changed(self, interface, changed, invalidated):
+        """Handles PropertiesChanged signal to update the connection state."""
+        if interface == "org.bluez.Device1" and "Connected" in changed:
+            self.connected = bool(changed["Connected"].value)
+            logging.info(f"Device {self.device_id} connection status updated: {self.connected}")
+
+    def setup_signal_handler(self):
+        """Attach signal handler to listen for connection status changes."""
+        if self.properties_changed_listener_active:
+            # Only set up the listener if it's not already active
+            return
+
+        if not self.device_properties_interface:
+            logging.warning(f"Device properties interface not initialized for {self.device_id}")
+            self.device_properties_interface = self.device_proxy.get_interface('org.freedesktop.DBus.Properties')
+        logging.debug(f"Setting up properties changed signal handler for {self.device_id}")
+        # noinspection PyUnresolvedReferences
+        self.device_properties_interface.on_properties_changed(self.properties_changed)
+        self.properties_changed_listener_active = True

--- a/fido2ble_to_uhid/fido2ble_to_uhid.py
+++ b/fido2ble_to_uhid/fido2ble_to_uhid.py
@@ -15,7 +15,10 @@ FIDO_STATUS_UUID = "f1d0fff2-deaa-ecee-b42f-c9ba7ed623bb"
 FIDO_CONTROL_POINT_LENGTH_UUID = "f1d0fff3-deaa-ecee-b42f-c9ba7ed623bb"
 FIDO_SERVICE_REVISION_BITFIELD_UUID = "f1d0fff4-deaa-ecee-b42f-c9ba7ed623bb"
 
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(
+    level=logging.DEBUG,
+    format="%(asctime)s.%(msecs)03d %(message)s",
+    datefmt='%I:%M:%S')
 logging.getLogger("UHIDDevice").setLevel(logging.ERROR)
 
 async def create_device(device_path, dbus_managed_objects, bus) -> CTAPBLEDevice:
@@ -38,7 +41,7 @@ async def create_device(device_path, dbus_managed_objects, bus) -> CTAPBLEDevice
     control_point_path = characteristic_paths[FIDO_CONTROL_POINT_UUID]
     control_point_length_path = characteristic_paths[FIDO_CONTROL_POINT_LENGTH_UUID]
     status_path = characteristic_paths[FIDO_STATUS_UUID]
-    return CTAPBLEDevice(device1, device_path, cached, control_point_path, control_point_length_path, status_path)
+    return CTAPBLEDevice(device_proxy, device1, device_path, cached, control_point_path, control_point_length_path, status_path)
 
 
 async def find_fido() -> dict[str, CTAPBLEDevice]:


### PR DESCRIPTION
This commit does a lot, but I was not able to separate it in a meaningful way.

Important parts:

Add reconnect logic where there earlier was simply an infinite wait/sleep loop. 
Make sure there is only one notify listener active at a time

Add a signal handler that listens to PropertiesChanged signal from the Connected property from dbus instead of setting it to true and false ourselves

Filter which tasks we cancel when disconnecting, so we don't cancel requests we receive while disconnecting. The window is about 3 seconds, so pretty significant, and since we want the app to not hold the connection too long, this will typically happen when a user has finished inputting a pin

Add try/except blocks to calls that go to dbus

Finally, add timestamp to logging

Part of #24 